### PR TITLE
fix: fix storybook issue

### DIFF
--- a/.changeset/ninety-ads-try.md
+++ b/.changeset/ninety-ads-try.md
@@ -1,0 +1,5 @@
+---
+"@ikona/cli": patch
+---
+
+fix storybook issue with `image-size` lib

--- a/packages/cli/__tests__/icons/generate-icon-file.test.ts
+++ b/packages/cli/__tests__/icons/generate-icon-file.test.ts
@@ -70,7 +70,9 @@ describe("generateIconFiles", () => {
 
     const hashContent = fs.readFileSync(context.hashPath, "utf-8");
     expect(hashContent).toMatchInlineSnapshot(`
-      "export const hash = '`);
+      "export const hash = 'e50b086ece17b1aef95e165676c128d0';
+      "
+    `);
   });
 
   it("should generate and optimize sprite", async () => {

--- a/packages/cli/__tests__/icons/generate-icon-file.test.ts
+++ b/packages/cli/__tests__/icons/generate-icon-file.test.ts
@@ -70,7 +70,7 @@ describe("generateIconFiles", () => {
 
     const hashContent = fs.readFileSync(context.hashPath, "utf-8");
     expect(hashContent).toMatchInlineSnapshot(`
-      "export const hash = 'e50b086ece17b1aef95e165676c128d0';
+      "export const hash = '${hash}';
       "
     `);
   });

--- a/packages/cli/__tests__/icons/generate-icon-file.test.ts
+++ b/packages/cli/__tests__/icons/generate-icon-file.test.ts
@@ -40,7 +40,7 @@ describe("generateIconFiles", () => {
     const spriteContent = fs.readFileSync(spritePath, "utf-8");
     expect(spriteContent).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 0 0" width="0" height="0">
       <defs>
       <symbol viewBox="0 0 24 24" id="icon1"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path></symbol>
       <symbol viewBox="0 0 24 24" id="icon2"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path></symbol>
@@ -70,9 +70,7 @@ describe("generateIconFiles", () => {
 
     const hashContent = fs.readFileSync(context.hashPath, "utf-8");
     expect(hashContent).toMatchInlineSnapshot(`
-      "export const hash = '${hash}';
-      "
-    `);
+      "export const hash = '`);
   });
 
   it("should generate and optimize sprite", async () => {

--- a/packages/cli/__tests__/icons/templates/svg-sprite.test.ts
+++ b/packages/cli/__tests__/icons/templates/svg-sprite.test.ts
@@ -12,7 +12,7 @@ describe("svgSpriteTemplate", () => {
 
     expect(result).toMatchInlineSnapshot(`
       "<?xml version="1.0" encoding="UTF-8"?>
-      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">
+      <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 0 0" width="0" height="0">
       <defs>
       <symbol viewBox="0 0 24 24" id="heart"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"></path></symbol>
       </defs>

--- a/packages/cli/src/icons/templates/svg-sprite.ts
+++ b/packages/cli/src/icons/templates/svg-sprite.ts
@@ -27,7 +27,7 @@ export function svgSpriteTemplate(iconsData: Array<IconData>) {
 
   return [
     `<?xml version="1.0" encoding="UTF-8"?>`,
-    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0">`,
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 0 0" width="0" height="0">`,
     `<defs>`, // for semantics: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/defs
     ...symbols,
     `</defs>`,


### PR DESCRIPTION
Fix storybook issue:

This causes storybook to mark SVG as invalid because `image-size` module fails to parse dimensions.

```
// Code from image-size
            const attrs = parseAttributes(root[0]);
            if (attrs.width && attrs.height) {
                return calculateByDimensions(attrs);
            }
            if (attrs.viewbox) {
                return calculateByViewbox(attrs, attrs.viewbox);
            }
```